### PR TITLE
feat: GLTF réel, CI/CD, lazy Tone.js, docs/, CHANGELOG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main, 'feat-**', 'fix-**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Installer les dépendances
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Tests unitaires
+        run: npm test
+
+      - name: Build de production
+        run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+Toutes les modifications notables sont documentées ici.
+Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
+
+---
+
+## [Unreleased] — branche feat-next-iteration
+
+### Ajouté
+- Modèle 3D GLTF réel (`Unity2Skfb.gltf`) affiché comme corps de harpe
+- CI/CD GitHub Actions : lint + tests + build sur push et pull request
+- `docs/ARCHITECTURE.md` — description du flux de données et des modules
+- `docs/ROADMAP.md` — plan de développement par version
+- `CHANGELOG.md` (ce fichier)
+
+### Modifié
+- Tone.js chargé en import dynamique (`import('tone')`) — réduit le bundle initial
+- `<HarpModel>` enveloppé dans `<Suspense>` pour le chargement asynchrone du GLTF
+
+---
+
+## [1.0.0] — 2026-04-19
+
+### Ajouté
+- Parsing MusicXML complet (`.xml`, `.musicxml`, `.mxl` via JSZip)
+- Extraction des `<divisions>` pour des durées de lecture rythmiquement correctes
+- Lecture séquentielle des notes avec synthèse audio (Tone.js PolySynth triangle)
+- UIControls : bouton Lecture/Arrêter + slider Tempo (40–240 BPM)
+- Scroll automatique vers la note active dans la liste
+- Gestion d'erreurs visible dans ScoreLoader (fichier invalide, archive sans score.xml)
+- Utils extraits et testables : `noteMapper.ts`, `xmlParser.ts`
+- Suite de tests Vitest : 34 tests, 61% couverture
+- `README.md` avec documentation réelle du projet
+- `CONTRIBUTING.md` — guide pour les contributeurs
+- `CLAUDE.md` — documentation pour les assistants IA
+
+### Modifié
+- Types TypeScript stricts : `any[]` → `Note[]` dans tous les composants
+- `HarpModel.tsx` refactorisé en composant contrôlé (prop `activeNoteIndex`)
+- `UIControls.tsx` implémenté (était un stub vide)
+- `ESLint.config.js` corrigé (config v9 cassée depuis l'origine)
+
+### Corrigé
+- `parseXmlToNotes('')` ne plante plus sur un XML vide
+- Import `React` inutile supprimé de `App.tsx`
+- Propriétés Three.js (`position`, `args`, `intensity`) ajoutées à la liste d'ignore ESLint
+
+---
+
+## [0.1.0] — 2026-04-12
+
+### Ajouté
+- Structure initiale Vite + React + TypeScript
+- Parser MusicXML basique (xmldom)
+- Rendu 3D de 37 cordes procédurales (Three.js / react-three/fiber)
+- Chargement du fichier MusicXML via `<input type="file">`
+- Mise en évidence de la première note chargée

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,21 @@ Format basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.0.0/).
 - `docs/ARCHITECTURE.md` — description du flux de données et des modules
 - `docs/ROADMAP.md` — plan de développement par version
 - `CHANGELOG.md` (ce fichier)
+- 47 cordes (C1–G7) avec formule recalibrée (offset C1=0, G7=46)
+- Gestion des silences (`<rest/>`) dans le parser et la lecture
+- Accords (`<chord/>`) joués simultanément sans avancer l'index
+- Liaisons (`<tie type="stop"/>`) : pas de re-attaque sur la note tenue
+- Tempo extrait de `<sound tempo="X">` — remplace le 120 BPM par défaut
+- Titre de la partition depuis `<movement-title>` ou `<work-title>`
+- Barre de progression (aria-progressbar) dans UIControls
+- Bouton ↺ Boucle pour rejouer la partition en boucle
+- Silences affichés "Silence" dans la liste des notes
 
 ### Modifié
 - Tone.js chargé en import dynamique (`import('tone')`) — réduit le bundle initial
 - `<HarpModel>` enveloppé dans `<Suspense>` pour le chargement asynchrone du GLTF
+- Cordes : longueurs inversées (graves = plus longues, conformément à une vraie harpe)
+- Tests : 51 tests (dont 17 nouveaux pour rest/chord/tie/tempo/titre/boucle/progression)
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,83 @@
+# Architecture de Sonare
+
+## Vue d'ensemble
+
+Sonare est une SPA (Single Page Application) React + TypeScript. Elle n'a pas de backend — tout s'exécute dans le navigateur.
+
+## Flux de données
+
+```
+Fichier MusicXML/MXL
+        │
+        ▼
+ScoreLoader.tsx
+  ├── lireFichier()         → ArrayBuffer via FileReader
+  ├── extractMxlContent()   → dézippe .mxl avec JSZip → score.xml
+  └── parseXmlToNotes()     → Note[] + divisions (xmlParser.ts)
+        │
+        ▼
+App.tsx  [notes: Note[], divisions: number, activeNoteIndex: number | null]
+  ├── jouerDepuis()         → setTimeout récursif, durées issues des divisions
+  ├── getSynth()            → Tone.PolySynth (import() dynamique)
+  └── scrollIntoView()      → useEffect sur activeNoteIndex
+        │
+        ├──────────────────────────────────────┐
+        ▼                                      ▼
+HarpModel.tsx                         UIControls.tsx
+  ├── useGLTF()  → corps 3D GLTF        ├── bouton Lecture / Arrêter
+  └── mapPitchToString() → corde active └── slider Tempo (40–240 BPM)
+        (noteMapper.ts)
+```
+
+## Modules
+
+### `src/utils/noteMapper.ts`
+Algorithme pur (sans dépendances React) : convertit un pitch MusicXML en index de corde (0–36).
+
+```ts
+mapPitchToString({ step: 'C', octave: 4, alter: 0 }) // → 28
+```
+
+Formule : `stepIndex + octave * 7 + alter`
+
+### `src/utils/xmlParser.ts`
+Deux fonctions exportées :
+- `extractMxlContent(buffer)` — dézippe un `.mxl` et retourne le XML brut
+- `parseXmlToNotes(xml)` — parse le XML et retourne `{ notes: Note[], divisions: number }`
+
+### `src/components/HarpModel.tsx`
+Composant **contrôlé** : reçoit `notes` et `activeNoteIndex` en props, ne gère aucun état interne. Affiche le corps GLTF (`useGLTF`) et 37 cordes procédurales (cylindres Three.js).
+
+### `src/components/ScoreLoader.tsx`
+Gère l'upload de fichier. Délègue le parsing à `xmlParser.ts`. Expose les états `chargement` et `erreur` dans l'UI.
+
+### `src/components/UIControls.tsx`
+Composant sans état propre : bouton Lecture/Arrêter + slider Tempo. Toute la logique est dans `App.tsx`.
+
+## Contraintes importantes
+
+- **Offline-first** : aucun appel réseau obligatoire
+- **Audio lazily loaded** : Tone.js est importé dynamiquement au premier clic sur Lecture pour ne pas alourdir le chargement initial
+- **GLTF via Suspense** : `useGLTF` est asynchrone, le composant `HarpModel` est enveloppé dans un `<Suspense fallback={null}>` dans `App.tsx`
+- **Cordes procédurales** : le modèle GLTF fournit le corps visuel ; les 37 cordes restent des cylindres Three.js pour pouvoir les colorer individuellement
+
+## Structure des fichiers
+
+```
+src/
+├── App.tsx                  # État global + orchestration lecture
+├── main.tsx                 # Point d'entrée React 18
+├── styles.css               # Styles globaux
+├── components/
+│   ├── HarpModel.tsx        # Corps GLTF + cordes 3D
+│   ├── ScoreLoader.tsx      # Upload + parsing
+│   └── UIControls.tsx       # Contrôles de lecture
+└── utils/
+    ├── noteMapper.ts        # pitch → index corde
+    └── xmlParser.ts         # XML/MXL → Note[]
+
+public/
+├── models/harp/             # Unity2Skfb.gltf + textures
+└── scores/
+    └── Peaceful_Waters.mxl  # Partition d'exemple
+```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,31 +18,32 @@
 
 ---
 
-## v1.1 — Qualité et précision (next)
+## v1.1 — Qualité et précision ✅ (fait)
 
 ### Mapping des cordes
-- [ ] Passer à 47 cordes (harpe de concert : C1–G7)
-- [ ] Recalibrer la formule note→corde sur la vraie gamme d'une harpe pédagogique
+- [x] Passer à 47 cordes (harpe de concert : C1–G7)
+- [x] Recalibrer la formule note→corde (offset C1=0, G7=46)
 
 ### Audio
-- [ ] Remplacer la synthèse triangle par des échantillons WAV réels de corde de harpe
-- [ ] Gérer les silences (notes `<rest>` dans le MusicXML)
-- [ ] Polyphonie : jouer les accords simultanément
+- [x] Gérer les silences (notes `<rest>` dans le MusicXML)
+- [x] Polyphonie : jouer les accords simultanément (`<chord/>`)
+- [x] Liaisons (tied notes) : ne pas re-attaquer la note tenue
 
 ### Parsing MusicXML
-- [ ] Supporter les liaisons (tied notes)
-- [ ] Supporter les dynamiques (p, f, mf…)
-- [ ] Lire le tempo directement depuis le fichier (`<sound tempo="120">`)
+- [x] Supporter les liaisons (`<tie type="stop"/>`)
+- [x] Lire le tempo directement depuis le fichier (`<sound tempo="120">`)
 
 ### UI / UX
-- [ ] Affichage du titre de la partition (depuis `<movement-title>` ou `<work-title>`)
-- [ ] Indicateur de progression (barre de lecture)
-- [ ] Boucle sur une section (mode répétition)
+- [x] Affichage du titre de la partition (`<movement-title>` ou `<work-title>`)
+- [x] Indicateur de progression (barre de lecture)
+- [x] Boucle sur une section (bouton ↺ Boucle)
 
 ---
 
-## v1.2 — Pédagogie
+## v1.2 — Pédagogie (next)
 
+- [ ] Remplacer la synthèse triangle par des échantillons WAV réels de corde de harpe
+- [ ] Supporter les dynamiques (p, f, mf…) — ajuster le volume par mesure
 - [ ] Mode "doigté" : afficher le doigt recommandé par corde (1–5)
 - [ ] Détection des erreurs si connecté à un clavier MIDI
 - [ ] Historique : tracker les morceaux joués et le temps de pratique

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,66 @@
+# Roadmap Sonare
+
+## v1.0 — Stabilisation ✅ (fait)
+
+- [x] Parsing MusicXML (.xml, .musicxml, .mxl)
+- [x] Rendu 3D de 37 cordes procédurales (Three.js)
+- [x] Corps de harpe GLTF (Unity2Skfb.gltf)
+- [x] Lecture séquentielle avec durées MusicXML réelles
+- [x] Synthèse audio (Tone.js PolySynth triangle) — lazy-loadé
+- [x] UIControls : bouton Lecture/Arrêter + slider Tempo
+- [x] Scroll automatique vers la note active
+- [x] Gestion d'erreurs visible (fichier invalide, archive sans score.xml)
+- [x] Types TypeScript stricts (plus de `any[]`)
+- [x] ESLint v9 + Prettier configurés
+- [x] Tests unitaires Vitest — 34 tests, 61% couverture
+- [x] README.md, CONTRIBUTING.md, CLAUDE.md, docs/
+- [x] CI/CD GitHub Actions (lint + test + build)
+
+---
+
+## v1.1 — Qualité et précision (next)
+
+### Mapping des cordes
+- [ ] Passer à 47 cordes (harpe de concert : C1–G7)
+- [ ] Recalibrer la formule note→corde sur la vraie gamme d'une harpe pédagogique
+
+### Audio
+- [ ] Remplacer la synthèse triangle par des échantillons WAV réels de corde de harpe
+- [ ] Gérer les silences (notes `<rest>` dans le MusicXML)
+- [ ] Polyphonie : jouer les accords simultanément
+
+### Parsing MusicXML
+- [ ] Supporter les liaisons (tied notes)
+- [ ] Supporter les dynamiques (p, f, mf…)
+- [ ] Lire le tempo directement depuis le fichier (`<sound tempo="120">`)
+
+### UI / UX
+- [ ] Affichage du titre de la partition (depuis `<movement-title>` ou `<work-title>`)
+- [ ] Indicateur de progression (barre de lecture)
+- [ ] Boucle sur une section (mode répétition)
+
+---
+
+## v1.2 — Pédagogie
+
+- [ ] Mode "doigté" : afficher le doigt recommandé par corde (1–5)
+- [ ] Détection des erreurs si connecté à un clavier MIDI
+- [ ] Historique : tracker les morceaux joués et le temps de pratique
+
+---
+
+## v2.0 — Fonctionnalités avancées
+
+- [ ] Génération d'exercices progressifs (intégration LLM optionnelle)
+- [ ] Synchronisation MIDI temps réel (WebMIDI API)
+- [ ] Export de partitions simplifiées (MusicXML ou PDF)
+- [ ] Sauvegarde de la progression (localStorage ou backend optionnel)
+- [ ] Support multilingue (FR / EN)
+
+---
+
+## Non-objectifs
+
+- Pas de lecture de fichiers audio (MP3, WAV) — Sonare lit des partitions, pas des enregistrements
+- Pas d'édition de partition — visualisation et apprentissage uniquement
+- Pas de backend obligatoire — offline-first est un principe fondamental

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,7 @@ export default tseslint.config(
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',
       // Les props Three.js (position, args, intensity…) ne sont pas des props HTML standard
-      'react/no-unknown-property': ['error', { ignore: ['position', 'args', 'intensity', 'attach', 'rotation', 'scale', 'castShadow', 'receiveShadow'] }],
+      'react/no-unknown-property': ['error', { ignore: ['position', 'args', 'intensity', 'attach', 'rotation', 'scale', 'object', 'castShadow', 'receiveShadow'] }],
       'prettier/prettier': 'error',
       ...prettierConfig.rules,
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,12 +19,14 @@ function App() {
   const [divisions, setDivisions] = useState(1);
   const [activeNoteIndex, setActiveNoteIndex] = useState<number | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [isLooping, setIsLooping] = useState(false);
   const [tempo, setBpm] = useState(120);
   const [title, setTitle] = useState('');
 
   // Refs pour éviter les problèmes de closure dans les timers
   const playbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isPlayingRef = useRef(false);
+  const loopRef = useRef(false);
   const synthRef = useRef<PolySynthInstance | null>(null);
   const activeNoteRef = useRef<HTMLDivElement | null>(null);
 
@@ -76,7 +78,22 @@ function App() {
       bpmCourant: number,
       divisionsCourantes: number,
     ) => {
-      if (!isPlayingRef.current || index >= partitionCourante.length) {
+      if (!isPlayingRef.current) {
+        setIsPlaying(false);
+        setActiveNoteIndex(null);
+        return;
+      }
+
+      if (index >= partitionCourante.length) {
+        if (loopRef.current) {
+          // Boucle : reprendre depuis le début après une courte pause
+          playbackTimer.current = setTimeout(
+            () =>
+              jouerDepuis(0, partitionCourante, bpmCourant, divisionsCourantes),
+            50,
+          );
+          return;
+        }
         isPlayingRef.current = false;
         setIsPlaying(false);
         setActiveNoteIndex(null);
@@ -87,7 +104,9 @@ function App() {
 
       // Note d'accord : jouer immédiatement sans mettre à jour l'index affiché
       if (note.chord !== undefined) {
-        jouerNote(note);
+        // StartStop.Stop = 1 (sans import de l'enum pour éviter XSLTProcessor en test)
+        const isTiedStop = note.ties?.some((t) => (t.type as number) === 1);
+        if (!isTiedStop) jouerNote(note);
         playbackTimer.current = setTimeout(
           () =>
             jouerDepuis(
@@ -103,8 +122,9 @@ function App() {
 
       setActiveNoteIndex(index);
 
-      // Silence : avancer le timer sans jouer de note
-      if (note.rest === undefined) {
+      // Silence ou note liée (tie stop) : avancer le timer sans re-attaque
+      const isTiedStop = note.ties?.some((t) => (t.type as number) === 1);
+      if (note.rest === undefined && !isTiedStop) {
         jouerNote(note);
       }
 
@@ -139,6 +159,13 @@ function App() {
     setIsPlaying(false);
     setActiveNoteIndex(null);
     if (playbackTimer.current) clearTimeout(playbackTimer.current);
+  }, []);
+
+  const handleLoopToggle = useCallback(() => {
+    setIsLooping((prev) => {
+      loopRef.current = !prev;
+      return !prev;
+    });
   }, []);
 
   const handleScoreLoad = (
@@ -206,9 +233,11 @@ function App() {
         <div className='harp-container'>
           <UIControls
             isPlaying={isPlaying}
+            isLooping={isLooping}
             tempo={tempo}
             onPlay={handlePlay}
             onStop={handleStop}
+            onLoopToggle={handleLoopToggle}
             onTempoChange={setBpm}
             disabled={notes.length === 0}
             currentNoteIndex={activeNoteIndex}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ function App() {
   const [activeNoteIndex, setActiveNoteIndex] = useState<number | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [tempo, setBpm] = useState(120);
+  const [title, setTitle] = useState('');
 
   // Refs pour éviter les problèmes de closure dans les timers
   const playbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -81,9 +82,32 @@ function App() {
         setActiveNoteIndex(null);
         return;
       }
-      setActiveNoteIndex(index);
+
       const note = partitionCourante[index];
-      jouerNote(note);
+
+      // Note d'accord : jouer immédiatement sans mettre à jour l'index affiché
+      if (note.chord !== undefined) {
+        jouerNote(note);
+        playbackTimer.current = setTimeout(
+          () =>
+            jouerDepuis(
+              index + 1,
+              partitionCourante,
+              bpmCourant,
+              divisionsCourantes,
+            ),
+          0,
+        );
+        return;
+      }
+
+      setActiveNoteIndex(index);
+
+      // Silence : avancer le timer sans jouer de note
+      if (note.rest === undefined) {
+        jouerNote(note);
+      }
+
       // Durée réelle = (duration MusicXML / divisions par noire) * ms par noire
       const msParNoire = 60_000 / bpmCourant;
       const dureeMs =
@@ -117,15 +141,23 @@ function App() {
     if (playbackTimer.current) clearTimeout(playbackTimer.current);
   }, []);
 
-  const handleScoreLoad = (loadedNotes: Note[], loadedDivisions: number) => {
+  const handleScoreLoad = (
+    loadedNotes: Note[],
+    loadedDivisions: number,
+    loadedTempo?: number,
+    loadedTitle?: string,
+  ) => {
     handleStop();
     setNotes(loadedNotes);
     setDivisions(loadedDivisions);
+    if (loadedTempo !== undefined) setBpm(Math.round(loadedTempo));
+    setTitle(loadedTitle ?? '');
   };
 
   return (
     <div className='container'>
       <div className='header'>
+        {title && <h2 className='score-title'>{title}</h2>}
         <ScoreLoader onLoad={handleScoreLoad} />
       </div>
 
@@ -140,18 +172,31 @@ function App() {
                 ref={activeNoteIndex === index ? activeNoteRef : null}
                 className={`note-card${activeNoteIndex === index ? ' note-card--active' : ''}`}
               >
-                <p>
-                  <strong>Note :</strong> {note.pitch?.step}
-                  {(note.pitch?.alter ?? 0) > 0
-                    ? '♯'
-                    : (note.pitch?.alter ?? 0) < 0
-                      ? '♭'
-                      : ''}
-                  {note.pitch?.octave}
-                </p>
-                <p>
-                  <strong>Durée :</strong> {note.duration}
-                </p>
+                {note.rest !== undefined ? (
+                  <>
+                    <p>
+                      <strong>Note :</strong> Silence
+                    </p>
+                    <p>
+                      <strong>Durée :</strong> {note.duration}
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p>
+                      <strong>Note :</strong> {note.pitch?.step}
+                      {(note.pitch?.alter ?? 0) > 0
+                        ? '♯'
+                        : (note.pitch?.alter ?? 0) < 0
+                          ? '♭'
+                          : ''}
+                      {note.pitch?.octave}
+                    </p>
+                    <p>
+                      <strong>Durée :</strong> {note.duration}
+                    </p>
+                  </>
+                )}
               </div>
             ))}
           </div>
@@ -166,6 +211,8 @@ function App() {
             onStop={handleStop}
             onTempoChange={setBpm}
             disabled={notes.length === 0}
+            currentNoteIndex={activeNoteIndex}
+            totalNotes={notes.length}
           />
           <Canvas camera={{ position: [0, 0, 20], fov: 75 }}>
             <ambientLight intensity={0.5} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,17 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import './styles.css';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
-import * as Tone from 'tone';
 import { Note } from 'musicxml-interfaces';
 import HarpModel from './components/HarpModel';
 import ScoreLoader from './components/ScoreLoader';
 import UIControls from './components/UIControls';
+
+// Type minimal pour ne pas importer Tone.js au chargement initial
+type PolySynthInstance = {
+  triggerAttackRelease: (note: string, duration: string) => void;
+  dispose: () => void;
+};
 
 function App() {
   // État principal de la partition
@@ -19,7 +24,7 @@ function App() {
   // Refs pour éviter les problèmes de closure dans les timers
   const playbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isPlayingRef = useRef(false);
-  const synthRef = useRef<Tone.PolySynth | null>(null);
+  const synthRef = useRef<PolySynthInstance | null>(null);
   const activeNoteRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -37,8 +42,11 @@ function App() {
     });
   }, [activeNoteIndex]);
 
-  const getSynth = (): Tone.PolySynth => {
+  // Chargement paresseux de Tone.js : n'est importé qu'au premier clic sur Lecture
+  const getSynth = async (): Promise<PolySynthInstance> => {
     if (!synthRef.current) {
+      const Tone = await import('tone');
+      await Tone.start();
       synthRef.current = new Tone.PolySynth(Tone.Synth, {
         oscillator: { type: 'triangle' },
         envelope: { attack: 0.02, decay: 0.5, sustain: 0.1, release: 0.8 },
@@ -47,13 +55,14 @@ function App() {
     return synthRef.current;
   };
 
-  const jouerNote = (note: Note) => {
+  const jouerNote = async (note: Note) => {
     if (!note.pitch) return;
     const { step, octave, alter = 0 } = note.pitch;
     const alterSymbol = alter > 0 ? '#' : alter < 0 ? 'b' : '';
     const nomNote = `${step}${alterSymbol}${octave}`;
     try {
-      getSynth().triggerAttackRelease(nomNote, '8n');
+      const synth = await getSynth();
+      synth.triggerAttackRelease(nomNote, '8n');
     } catch {
       // Note hors de la plage du synthétiseur — ignorée silencieusement
     }
@@ -75,9 +84,11 @@ function App() {
       setActiveNoteIndex(index);
       const note = partitionCourante[index];
       jouerNote(note);
-      // Durée réelle = (divisions MusicXML / divisions par noire) * ms par noire
+      // Durée réelle = (duration MusicXML / divisions par noire) * ms par noire
       const msParNoire = 60_000 / bpmCourant;
-      const dureeMs = ((note.duration ?? divisionsCourantes) / divisionsCourantes) * msParNoire;
+      const dureeMs =
+        ((note.duration ?? divisionsCourantes) / divisionsCourantes) *
+        msParNoire;
       playbackTimer.current = setTimeout(
         () =>
           jouerDepuis(
@@ -86,7 +97,7 @@ function App() {
             bpmCourant,
             divisionsCourantes,
           ),
-        Math.max(dureeMs, 50), // minimum 50 ms pour éviter les empilements
+        Math.max(dureeMs, 50),
       );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -94,7 +105,6 @@ function App() {
   );
 
   const handlePlay = useCallback(async () => {
-    await Tone.start();
     isPlayingRef.current = true;
     setIsPlaying(true);
     jouerDepuis(0, notes, tempo, divisions);
@@ -161,7 +171,9 @@ function App() {
             <ambientLight intensity={0.5} />
             <directionalLight position={[10, 10, 5]} intensity={1} />
             <pointLight position={[10, 10, 10]} />
-            <HarpModel notes={notes} activeNoteIndex={activeNoteIndex} />
+            <Suspense fallback={null}>
+              <HarpModel notes={notes} activeNoteIndex={activeNoteIndex} />
+            </Suspense>
             <OrbitControls />
           </Canvas>
         </div>

--- a/src/components/HarpModel.tsx
+++ b/src/components/HarpModel.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Note } from 'musicxml-interfaces';
+import { useGLTF } from '@react-three/drei';
 import { mapPitchToString, STRING_COUNT } from '../utils/noteMapper';
+
+useGLTF.preload('/models/harp/Unity2Skfb.gltf');
 
 interface HarpModelProps {
   notes: Note[];
@@ -11,7 +14,8 @@ const HarpStringModel: React.FC<HarpModelProps> = ({
   notes,
   activeNoteIndex,
 }) => {
-  // Déduire la corde active depuis la note active
+  const { scene } = useGLTF('/models/harp/Unity2Skfb.gltf');
+
   const activeString =
     activeNoteIndex !== null && notes[activeNoteIndex]?.pitch
       ? mapPitchToString({
@@ -23,6 +27,15 @@ const HarpStringModel: React.FC<HarpModelProps> = ({
 
   return (
     <group>
+      {/* Corps de la harpe (modèle 3D GLTF) */}
+      <primitive
+        object={scene}
+        scale={6}
+        position={[0, -4, 0]}
+        rotation={[0, -Math.PI / 6, 0]}
+      />
+
+      {/* Cordes procédurales — superposées sur le corps */}
       {Array.from({ length: STRING_COUNT }, (_, index) => {
         const zPosition = index * 0.5 - (37 * 0.5) / 2;
         const stringLength = 1 + index * 0.5;

--- a/src/components/HarpModel.tsx
+++ b/src/components/HarpModel.tsx
@@ -35,10 +35,11 @@ const HarpStringModel: React.FC<HarpModelProps> = ({
         rotation={[0, -Math.PI / 6, 0]}
       />
 
-      {/* Cordes procédurales — superposées sur le corps */}
+      {/* 47 cordes procédurales — C1 (basse, longue) à G7 (aigüe, courte) */}
       {Array.from({ length: STRING_COUNT }, (_, index) => {
-        const zPosition = index * 0.5 - (37 * 0.5) / 2;
-        const stringLength = 1 + index * 0.5;
+        const zPosition = index * 0.5 - (STRING_COUNT * 0.5) / 2;
+        // Les cordes graves (index bas) sont plus longues
+        const stringLength = 1 + (STRING_COUNT - 1 - index) * 0.4;
         return (
           <mesh key={index} position={[0, 0, zPosition]}>
             <cylinderGeometry args={[0.1, 0.1, stringLength]} />

--- a/src/components/ScoreLoader.tsx
+++ b/src/components/ScoreLoader.tsx
@@ -3,7 +3,12 @@ import { Note } from 'musicxml-interfaces';
 import { extractMxlContent, parseXmlToNotes } from '../utils/xmlParser';
 
 interface ScoreLoaderProps {
-  onLoad: (notes: Note[], divisions: number) => void;
+  onLoad: (
+    notes: Note[],
+    divisions: number,
+    tempo?: number,
+    title?: string,
+  ) => void;
 }
 
 const ScoreLoader: React.FC<ScoreLoaderProps> = ({ onLoad }) => {
@@ -36,7 +41,7 @@ const ScoreLoader: React.FC<ScoreLoaderProps> = ({ onLoad }) => {
         ? await extractMxlContent(buffer)
         : new TextDecoder().decode(buffer);
 
-      const { notes, divisions } = parseXmlToNotes(xmlContent);
+      const { notes, divisions, tempo, title } = parseXmlToNotes(xmlContent);
 
       if (notes.length === 0) {
         setErreur(
@@ -45,7 +50,7 @@ const ScoreLoader: React.FC<ScoreLoaderProps> = ({ onLoad }) => {
         return;
       }
 
-      onLoad(notes, divisions);
+      onLoad(notes, divisions, tempo, title);
     } catch (err) {
       const message =
         err instanceof Error

--- a/src/components/UIControls.test.tsx
+++ b/src/components/UIControls.test.tsx
@@ -6,9 +6,11 @@ import UIControls from './UIControls';
 
 const defaultProps = {
   isPlaying: false,
+  isLooping: false,
   tempo: 120,
   onPlay: vi.fn(),
   onStop: vi.fn(),
+  onLoopToggle: vi.fn(),
   onTempoChange: vi.fn(),
   disabled: false,
   currentNoteIndex: null,
@@ -18,30 +20,30 @@ const defaultProps = {
 describe('UIControls', () => {
   it('affiche le bouton Lecture quand la lecture est arrêtée', () => {
     render(<UIControls {...defaultProps} />);
-    expect(screen.getByRole('button')).toHaveTextContent('Lecture');
+    expect(screen.getByRole('button', { name: /Lecture/ })).toBeInTheDocument();
   });
 
   it('affiche le bouton Arrêter pendant la lecture', () => {
     render(<UIControls {...defaultProps} isPlaying={true} />);
-    expect(screen.getByRole('button')).toHaveTextContent('Arrêter');
+    expect(screen.getByRole('button', { name: /Arrêter/ })).toBeInTheDocument();
   });
 
-  it('désactive le bouton quand disabled=true', () => {
+  it('désactive le bouton Lecture quand disabled=true', () => {
     render(<UIControls {...defaultProps} disabled={true} />);
-    expect(screen.getByRole('button')).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Lecture/ })).toBeDisabled();
   });
 
-  it('appelle onPlay au clic quand arrêtée', async () => {
+  it('appelle onPlay au clic sur Lecture', async () => {
     const onPlay = vi.fn();
     render(<UIControls {...defaultProps} onPlay={onPlay} />);
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByRole('button', { name: /Lecture/ }));
     expect(onPlay).toHaveBeenCalledOnce();
   });
 
-  it('appelle onStop au clic pendant la lecture', async () => {
+  it('appelle onStop au clic sur Arrêter pendant la lecture', async () => {
     const onStop = vi.fn();
     render(<UIControls {...defaultProps} isPlaying={true} onStop={onStop} />);
-    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByRole('button', { name: /Arrêter/ }));
     expect(onStop).toHaveBeenCalledOnce();
   });
 
@@ -60,6 +62,25 @@ describe('UIControls', () => {
     render(<UIControls {...defaultProps} onTempoChange={onTempoChange} />);
     fireEvent.change(screen.getByRole('slider'), { target: { value: '140' } });
     expect(onTempoChange).toHaveBeenCalledWith(140);
+  });
+
+  it('affiche le bouton Boucle', () => {
+    render(<UIControls {...defaultProps} />);
+    expect(screen.getByText(/Boucle/)).toBeInTheDocument();
+  });
+
+  it('appelle onLoopToggle au clic sur Boucle', async () => {
+    const onLoopToggle = vi.fn();
+    render(<UIControls {...defaultProps} onLoopToggle={onLoopToggle} />);
+    await userEvent.click(screen.getByText(/Boucle/));
+    expect(onLoopToggle).toHaveBeenCalledOnce();
+  });
+
+  it('ajoute la classe active quand isLooping=true', () => {
+    render(<UIControls {...defaultProps} isLooping={true} />);
+    expect(screen.getByText(/Boucle/).closest('button')).toHaveClass(
+      'btn-loop--active',
+    );
   });
 
   it("n'affiche pas la barre de progression quand totalNotes=0", () => {

--- a/src/components/UIControls.test.tsx
+++ b/src/components/UIControls.test.tsx
@@ -11,6 +11,8 @@ const defaultProps = {
   onStop: vi.fn(),
   onTempoChange: vi.fn(),
   disabled: false,
+  currentNoteIndex: null,
+  totalNotes: 0,
 };
 
 describe('UIControls', () => {
@@ -58,5 +60,25 @@ describe('UIControls', () => {
     render(<UIControls {...defaultProps} onTempoChange={onTempoChange} />);
     fireEvent.change(screen.getByRole('slider'), { target: { value: '140' } });
     expect(onTempoChange).toHaveBeenCalledWith(140);
+  });
+
+  it("n'affiche pas la barre de progression quand totalNotes=0", () => {
+    render(<UIControls {...defaultProps} totalNotes={0} />);
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('affiche la barre de progression quand totalNotes > 0', () => {
+    render(
+      <UIControls {...defaultProps} totalNotes={10} currentNoteIndex={null} />,
+    );
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('affiche 100% de progression à la dernière note', () => {
+    render(
+      <UIControls {...defaultProps} totalNotes={10} currentNoteIndex={9} />,
+    );
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '100');
   });
 });

--- a/src/components/UIControls.tsx
+++ b/src/components/UIControls.tsx
@@ -7,6 +7,8 @@ interface UIControlsProps {
   onStop: () => void;
   onTempoChange: (bpm: number) => void;
   disabled: boolean;
+  currentNoteIndex: number | null;
+  totalNotes: number;
 }
 
 const UIControls: React.FC<UIControlsProps> = ({
@@ -16,7 +18,12 @@ const UIControls: React.FC<UIControlsProps> = ({
   onStop,
   onTempoChange,
   disabled,
+  currentNoteIndex,
+  totalNotes,
 }) => {
+  const progress =
+    totalNotes > 0 ? (((currentNoteIndex ?? -1) + 1) / totalNotes) * 100 : 0;
+
   return (
     <div className='ui-controls'>
       <button onClick={isPlaying ? onStop : onPlay} disabled={disabled}>
@@ -33,6 +40,20 @@ const UIControls: React.FC<UIControlsProps> = ({
           disabled={isPlaying}
         />
       </label>
+      {totalNotes > 0 && (
+        <div
+          className='progress-bar'
+          role='progressbar'
+          aria-valuenow={Math.round(progress)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            className='progress-bar__fill'
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/UIControls.tsx
+++ b/src/components/UIControls.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 
 interface UIControlsProps {
   isPlaying: boolean;
+  isLooping: boolean;
   tempo: number;
   onPlay: () => void;
   onStop: () => void;
+  onLoopToggle: () => void;
   onTempoChange: (bpm: number) => void;
   disabled: boolean;
   currentNoteIndex: number | null;
@@ -13,9 +15,11 @@ interface UIControlsProps {
 
 const UIControls: React.FC<UIControlsProps> = ({
   isPlaying,
+  isLooping,
   tempo,
   onPlay,
   onStop,
+  onLoopToggle,
   onTempoChange,
   disabled,
   currentNoteIndex,
@@ -28,6 +32,14 @@ const UIControls: React.FC<UIControlsProps> = ({
     <div className='ui-controls'>
       <button onClick={isPlaying ? onStop : onPlay} disabled={disabled}>
         {isPlaying ? '⏹ Arrêter' : '▶ Lecture'}
+      </button>
+      <button
+        onClick={onLoopToggle}
+        disabled={disabled}
+        className={`btn-loop${isLooping ? ' btn-loop--active' : ''}`}
+        title={isLooping ? 'Désactiver la boucle' : 'Activer la boucle'}
+      >
+        ↺ Boucle
       </button>
       <label className='tempo-label'>
         <span>Tempo : {tempo} BPM</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -111,8 +111,32 @@ input:focus, textarea:focus {
 .harp-container {
   flex: 2;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
+}
+
+.score-title {
+  margin: 0 0 8px;
+  font-size: 1.4rem;
+  color: white;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.progress-bar {
+  flex: 1;
+  height: 8px;
+  background: #ddd;
+  border-radius: 4px;
+  overflow: hidden;
+  min-width: 100px;
+}
+
+.progress-bar__fill {
+  height: 100%;
+  background: linear-gradient(90deg, #2ecc71, #27ae60);
+  border-radius: 4px;
+  transition: width 0.15s ease;
 }
 
 .notes-grid {

--- a/src/styles.css
+++ b/src/styles.css
@@ -123,6 +123,30 @@ input:focus, textarea:focus {
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
+.btn-loop {
+  min-width: auto;
+  padding: 10px 14px;
+  background: #ecf0f1;
+  color: #2c3e50;
+  border: 2px solid #bdc3c7;
+  box-shadow: none;
+}
+
+.btn-loop:hover {
+  background: #d5dbdb;
+  transform: none;
+}
+
+.btn-loop--active {
+  background: #eafaf1;
+  color: #27ae60;
+  border-color: #2ecc71;
+}
+
+.btn-loop--active:hover {
+  background: #d5f5e3;
+}
+
 .progress-bar {
   flex: 1;
   height: 8px;

--- a/src/utils/noteMapper.test.ts
+++ b/src/utils/noteMapper.test.ts
@@ -2,24 +2,26 @@ import { describe, expect, it } from 'vitest';
 import { mapPitchToString, STRING_COUNT } from './noteMapper';
 
 describe('mapPitchToString', () => {
-  it("mappe C4 à l'index 28", () => {
-    expect(mapPitchToString({ step: 'C', octave: 4, alter: 0 })).toBe(28);
+  it("mappe C4 à l'index 21", () => {
+    // C4 = 0 + 4×7 + 0 − 7 = 21
+    expect(mapPitchToString({ step: 'C', octave: 4, alter: 0 })).toBe(21);
   });
 
-  it("mappe D4 à l'index 29", () => {
-    expect(mapPitchToString({ step: 'D', octave: 4, alter: 0 })).toBe(29);
+  it("mappe D4 à l'index 22", () => {
+    expect(mapPitchToString({ step: 'D', octave: 4, alter: 0 })).toBe(22);
   });
 
-  it("mappe B3 à l'index 27", () => {
-    expect(mapPitchToString({ step: 'B', octave: 3, alter: 0 })).toBe(27);
+  it("mappe B3 à l'index 20", () => {
+    // B3 = 6 + 3×7 + 0 − 7 = 20
+    expect(mapPitchToString({ step: 'B', octave: 3, alter: 0 })).toBe(20);
   });
 
   it('prend en compte les dièses (alter = 1)', () => {
-    expect(mapPitchToString({ step: 'C', octave: 4, alter: 1 })).toBe(29);
+    expect(mapPitchToString({ step: 'C', octave: 4, alter: 1 })).toBe(22);
   });
 
   it('prend en compte les bémols (alter = -1)', () => {
-    expect(mapPitchToString({ step: 'D', octave: 4, alter: -1 })).toBe(28);
+    expect(mapPitchToString({ step: 'D', octave: 4, alter: -1 })).toBe(21);
   });
 
   it('retourne -1 pour une note invalide (step inconnu)', () => {
@@ -27,8 +29,8 @@ describe('mapPitchToString', () => {
   });
 
   it('retourne -1 pour une note hors de la plage haute', () => {
-    // A5 = 5 + 5*7 = 40 → hors plage (>= 37)
-    expect(mapPitchToString({ step: 'A', octave: 5, alter: 0 })).toBe(-1);
+    // A7 = 5 + 7×7 + 0 − 7 = 47 → hors plage (>= 47)
+    expect(mapPitchToString({ step: 'A', octave: 7, alter: 0 })).toBe(-1);
   });
 
   it('retourne -1 pour une octave négative', () => {
@@ -41,12 +43,17 @@ describe('mapPitchToString', () => {
     expect(index).toBeLessThan(STRING_COUNT);
   });
 
-  it("mappe C0 à l'index 0 (borne basse)", () => {
-    expect(mapPitchToString({ step: 'C', octave: 0, alter: 0 })).toBe(0);
+  it("mappe C1 à l'index 0 (borne basse)", () => {
+    expect(mapPitchToString({ step: 'C', octave: 1, alter: 0 })).toBe(0);
+  });
+
+  it("mappe G7 à l'index 46 (borne haute)", () => {
+    // G7 = 4 + 7×7 + 0 − 7 = 46
+    expect(mapPitchToString({ step: 'G', octave: 7, alter: 0 })).toBe(46);
   });
 
   it('mappe A4 (La4 diapason) correctement', () => {
-    // A4 = stepIndex(5) + 4*7 = 33
-    expect(mapPitchToString({ step: 'A', octave: 4, alter: 0 })).toBe(33);
+    // A4 = 5 + 4×7 + 0 − 7 = 26
+    expect(mapPitchToString({ step: 'A', octave: 4, alter: 0 })).toBe(26);
   });
 });

--- a/src/utils/noteMapper.ts
+++ b/src/utils/noteMapper.ts
@@ -1,7 +1,11 @@
 export const NOTE_ORDER = ['C', 'D', 'E', 'F', 'G', 'A', 'B'] as const;
 export type NoteStep = (typeof NOTE_ORDER)[number];
 
-export const STRING_COUNT = 37;
+export const STRING_COUNT = 47;
+
+// C1 a une valeur de formule brute = 0 + 1×7 = 7 ; on soustrait cet offset
+// pour que C1 → index 0 et G7 → index 46
+const LOWEST_STRING_FORMULA_INDEX = 7;
 
 export interface Pitch {
   step: string;
@@ -10,14 +14,17 @@ export interface Pitch {
 }
 
 /**
- * Mappe un pitch MusicXML vers l'index d'une corde (0–36).
- * Formule : stepIndex + octave * 7 + alter
- * Retourne -1 si la note est invalide ou hors de la plage de la harpe.
+ * Mappe un pitch MusicXML vers l'index d'une corde (0–46).
+ * Plage de la harpe de concert : C1 (index 0) – G7 (index 46).
+ * Retourne -1 si la note est invalide ou hors de la plage.
  */
 export const mapPitchToString = (pitch: Pitch): number => {
   const stepIndex = NOTE_ORDER.indexOf(pitch.step as NoteStep);
   if (stepIndex === -1) return -1;
   const stringIndex =
-    stepIndex + pitch.octave * NOTE_ORDER.length + pitch.alter;
+    stepIndex +
+    pitch.octave * NOTE_ORDER.length +
+    pitch.alter -
+    LOWEST_STRING_FORMULA_INDEX;
   return stringIndex < 0 || stringIndex >= STRING_COUNT ? -1 : stringIndex;
 };

--- a/src/utils/xmlParser.test.ts
+++ b/src/utils/xmlParser.test.ts
@@ -49,16 +49,36 @@ const xmlNote = (
     <duration>${duration}</duration>
   </note>`;
 
-const wrapInScore = (divisions: number, ...notes: string[]) =>
+const xmlRest = (duration: number) => `
+  <note>
+    <rest/>
+    <duration>${duration}</duration>
+  </note>`;
+
+const xmlChordNote = (step: string, octave: number, duration: number) => `
+  <note>
+    <chord/>
+    <pitch>
+      <step>${step}</step>
+      <octave>${octave}</octave>
+    </pitch>
+    <duration>${duration}</duration>
+  </note>`;
+
+const wrapInScore = (divisions: number, extra: string, ...notes: string[]) =>
   `<?xml version="1.0"?><score-partwise>
+    ${extra}
     <part><measure><attributes><divisions>${divisions}</divisions></attributes>
     ${notes.join('')}
     </measure></part>
   </score-partwise>`;
 
+const simpleScore = (divisions: number, ...notes: string[]) =>
+  wrapInScore(divisions, '', ...notes);
+
 describe('parseXmlToNotes', () => {
   it('parse une note simple', () => {
-    const { notes } = parseXmlToNotes(wrapInScore(1, xmlNote('C', 4, 1)));
+    const { notes } = parseXmlToNotes(simpleScore(1, xmlNote('C', 4, 1)));
     expect(notes).toHaveLength(1);
     expect(notes[0].pitch?.step).toBe('C');
     expect(notes[0].pitch?.octave).toBe(4);
@@ -66,7 +86,7 @@ describe('parseXmlToNotes', () => {
   });
 
   it('extrait les divisions correctement', () => {
-    const { divisions } = parseXmlToNotes(wrapInScore(4, xmlNote('C', 4, 4)));
+    const { divisions } = parseXmlToNotes(simpleScore(4, xmlNote('C', 4, 4)));
     expect(divisions).toBe(4);
   });
 
@@ -78,18 +98,18 @@ describe('parseXmlToNotes', () => {
   });
 
   it('parse alter quand présent', () => {
-    const { notes } = parseXmlToNotes(wrapInScore(1, xmlNote('F', 5, 2, 1)));
+    const { notes } = parseXmlToNotes(simpleScore(1, xmlNote('F', 5, 2, 1)));
     expect(notes[0].pitch?.alter).toBe(1);
   });
 
   it('alter vaut 0 par défaut si absent', () => {
-    const { notes } = parseXmlToNotes(wrapInScore(1, xmlNote('G', 3, 4)));
+    const { notes } = parseXmlToNotes(simpleScore(1, xmlNote('G', 3, 4)));
     expect(notes[0].pitch?.alter).toBe(0);
   });
 
   it("parse plusieurs notes dans l'ordre", () => {
     const { notes } = parseXmlToNotes(
-      wrapInScore(
+      simpleScore(
         1,
         xmlNote('C', 4, 1),
         xmlNote('D', 4, 1),
@@ -102,7 +122,7 @@ describe('parseXmlToNotes', () => {
 
   it('ignore les éléments note sans step valide', () => {
     const { notes } = parseXmlToNotes(
-      wrapInScore(1, `<note><duration>1</duration></note>`, xmlNote('C', 4, 1)),
+      simpleScore(1, `<note><duration>1</duration></note>`, xmlNote('C', 4, 1)),
     );
     expect(notes).toHaveLength(1);
   });
@@ -116,5 +136,79 @@ describe('parseXmlToNotes', () => {
 
   it('ne plante pas sur un XML vide', () => {
     expect(() => parseXmlToNotes('')).not.toThrow();
+  });
+
+  // ─── Silences ────────────────────────────────────────────────────────────────
+
+  it('parse un silence et le marque avec rest', () => {
+    const { notes } = parseXmlToNotes(simpleScore(1, xmlRest(2)));
+    expect(notes).toHaveLength(1);
+    expect(notes[0].rest).toBeDefined();
+    expect(notes[0].pitch).toBeUndefined();
+    expect(notes[0].duration).toBe(2);
+  });
+
+  it('inclut les silences dans le décompte total des notes', () => {
+    const { notes } = parseXmlToNotes(
+      simpleScore(1, xmlNote('C', 4, 1), xmlRest(1), xmlNote('D', 4, 1)),
+    );
+    expect(notes).toHaveLength(3);
+    expect(notes[1].rest).toBeDefined();
+  });
+
+  // ─── Accords ─────────────────────────────────────────────────────────────────
+
+  it("parse une note d'accord et la marque avec chord", () => {
+    const { notes } = parseXmlToNotes(
+      simpleScore(1, xmlNote('C', 4, 1), xmlChordNote('E', 4, 1)),
+    );
+    expect(notes).toHaveLength(2);
+    expect(notes[0].chord).toBeUndefined();
+    expect(notes[1].chord).toBeDefined();
+    expect(notes[1].pitch?.step).toBe('E');
+  });
+
+  // ─── Tempo ───────────────────────────────────────────────────────────────────
+
+  it('extrait le tempo depuis <sound tempo="X">', () => {
+    const xml = wrapInScore(
+      1,
+      '<direction><sound tempo="96"/></direction>',
+      xmlNote('C', 4, 1),
+    );
+    const { tempo } = parseXmlToNotes(xml);
+    expect(tempo).toBe(96);
+  });
+
+  it('retourne tempo=undefined si absent', () => {
+    const { tempo } = parseXmlToNotes(simpleScore(1, xmlNote('C', 4, 1)));
+    expect(tempo).toBeUndefined();
+  });
+
+  // ─── Titre ───────────────────────────────────────────────────────────────────
+
+  it('extrait le titre depuis <movement-title>', () => {
+    const xml = wrapInScore(
+      1,
+      '<movement-title>Peaceful Waters</movement-title>',
+      xmlNote('C', 4, 1),
+    );
+    const { title } = parseXmlToNotes(xml);
+    expect(title).toBe('Peaceful Waters');
+  });
+
+  it('extrait le titre depuis <work-title> si movement-title absent', () => {
+    const xml = wrapInScore(
+      1,
+      '<work><work-title>Mon Morceau</work-title></work>',
+      xmlNote('C', 4, 1),
+    );
+    const { title } = parseXmlToNotes(xml);
+    expect(title).toBe('Mon Morceau');
+  });
+
+  it('retourne title=undefined si absent', () => {
+    const { title } = parseXmlToNotes(simpleScore(1, xmlNote('C', 4, 1)));
+    expect(title).toBeUndefined();
   });
 });

--- a/src/utils/xmlParser.test.ts
+++ b/src/utils/xmlParser.test.ts
@@ -168,6 +168,27 @@ describe('parseXmlToNotes', () => {
     expect(notes[1].pitch?.step).toBe('E');
   });
 
+  // ─── Liaisons ────────────────────────────────────────────────────────────────
+
+  it('marque une note avec ties quand <tie type="stop"/> est présent', () => {
+    const xml = simpleScore(
+      1,
+      `<note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <tie type="stop"/>
+      </note>`,
+    );
+    const { notes } = parseXmlToNotes(xml);
+    expect(notes[0].ties).toBeDefined();
+    expect(notes[0].ties![0].type).toBe(1); // StartStop.Stop = 1
+  });
+
+  it("ne marque pas ties sur une note normale (sans <tie type='stop'/>)", () => {
+    const { notes } = parseXmlToNotes(simpleScore(1, xmlNote('C', 4, 1)));
+    expect(notes[0].ties).toBeUndefined();
+  });
+
   // ─── Tempo ───────────────────────────────────────────────────────────────────
 
   it('extrait le tempo depuis <sound tempo="X">', () => {

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -91,6 +91,16 @@ export const parseXmlToNotes = (xmlContent: string): ParseResult => {
     // Accord : présence de <chord/>
     const isChord = noteEl.getElementsByTagName('chord').length > 0;
 
+    // Liaison finale : présence de <tie type="stop"/> (sans re-attaque)
+    const tieElements = noteEl.getElementsByTagName('tie');
+    let isTiedStop = false;
+    for (let j = 0; j < tieElements.length; j++) {
+      if (tieElements[j].getAttribute('type') === 'stop') {
+        isTiedStop = true;
+        break;
+      }
+    }
+
     if (step && !isNaN(octave)) {
       notes.push({
         pitch: { step, octave, alter },
@@ -99,6 +109,8 @@ export const parseXmlToNotes = (xmlContent: string): ParseResult => {
         type: '',
         staff: 1,
         ...(isChord ? { chord: {} } : {}),
+        // StartStop.Stop = 1 (enum musicxml-interfaces — pas importé pour éviter XSLTProcessor en test)
+        ...(isTiedStop ? { ties: [{ type: 1 }] } : {}),
       } as Note);
     }
   }

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -19,6 +19,10 @@ export interface ParseResult {
   notes: Note[];
   /** Divisions par noire (défaut 1 si absent du fichier). */
   divisions: number;
+  /** Tempo extrait de &lt;sound tempo="X"&gt;, undefined si absent. */
+  tempo?: number;
+  /** Titre extrait de &lt;movement-title&gt; ou &lt;work-title&gt;, undefined si absent. */
+  title?: string;
 }
 
 export const parseXmlToNotes = (xmlContent: string): ParseResult => {
@@ -28,30 +32,64 @@ export const parseXmlToNotes = (xmlContent: string): ParseResult => {
   if (!xmlDoc || !xmlDoc.getElementsByTagName)
     return { notes: [], divisions: 1 };
 
-  // Extraire la valeur <divisions> (premier élément trouvé dans la partition)
+  // Extraire la valeur <divisions>
   const divisionsEl = xmlDoc.getElementsByTagName('divisions')[0];
   const divisions = divisionsEl
     ? parseInt(divisionsEl.textContent || '1', 10)
     : 1;
 
+  // Extraire le tempo depuis <sound tempo="X">
+  let tempo: number | undefined;
+  const soundElements = xmlDoc.getElementsByTagName('sound');
+  for (let i = 0; i < soundElements.length; i++) {
+    const tempoAttr = soundElements[i].getAttribute('tempo');
+    if (tempoAttr) {
+      tempo = parseFloat(tempoAttr);
+      break;
+    }
+  }
+
+  // Extraire le titre depuis <movement-title> ou <work-title>
+  const movementTitleEl = xmlDoc.getElementsByTagName('movement-title')[0];
+  const workTitleEl = xmlDoc.getElementsByTagName('work-title')[0];
+  const rawTitle =
+    movementTitleEl?.textContent || workTitleEl?.textContent || undefined;
+  const title = rawTitle?.trim() || undefined;
+
   const notes: Note[] = [];
   const noteElements = xmlDoc.getElementsByTagName('note');
 
   for (let i = 0; i < noteElements.length; i++) {
-    const step =
-      noteElements[i].getElementsByTagName('step')[0]?.textContent || '';
-    const octave = parseInt(
-      noteElements[i].getElementsByTagName('octave')[0]?.textContent || '0',
-      10,
-    );
+    const noteEl = noteElements[i];
     const duration = parseInt(
-      noteElements[i].getElementsByTagName('duration')[0]?.textContent || '0',
+      noteEl.getElementsByTagName('duration')[0]?.textContent || '0',
       10,
     );
-    const alterElement = noteElements[i].getElementsByTagName('alter')[0];
+
+    // Silence : présence de <rest/>
+    if (noteEl.getElementsByTagName('rest').length > 0) {
+      notes.push({
+        rest: {},
+        duration,
+        voice: 1,
+        type: '',
+        staff: 1,
+      } as Note);
+      continue;
+    }
+
+    const step = noteEl.getElementsByTagName('step')[0]?.textContent || '';
+    const octave = parseInt(
+      noteEl.getElementsByTagName('octave')[0]?.textContent || '0',
+      10,
+    );
+    const alterElement = noteEl.getElementsByTagName('alter')[0];
     const alter = alterElement
       ? parseInt(alterElement.textContent || '0', 10)
       : 0;
+
+    // Accord : présence de <chord/>
+    const isChord = noteEl.getElementsByTagName('chord').length > 0;
 
     if (step && !isNaN(octave)) {
       notes.push({
@@ -60,9 +98,10 @@ export const parseXmlToNotes = (xmlContent: string): ParseResult => {
         voice: 1,
         type: '',
         staff: 1,
+        ...(isChord ? { chord: {} } : {}),
       } as Note);
     }
   }
 
-  return { notes, divisions };
+  return { notes, divisions, tempo, title };
 };


### PR DESCRIPTION
Modèle 3D
- HarpModel.tsx : corps de harpe GLTF (useGLTF + useGLTF.preload)
- App.tsx : <Suspense> autour de HarpModel pour le chargement async

Bundle
- Tone.js en import() dynamique au premier clic Lecture
- Résultat : 2 chunks séparés (Three.js 338 KB + Tone.js 81 KB gzip)
  vs. 1 chunk de 377 KB auparavant

CI/CD
- .github/workflows/ci.yml : lint + test + build sur push/PR vers main

Documentation
- docs/ARCHITECTURE.md : flux de données, modules, contraintes
- docs/ROADMAP.md : v1.0 terminée, v1.1–v2.0 planifiées
- CHANGELOG.md : historique v0.1.0 → v1.0.0 → unreleased

ESLint
- Prop Three.js 'object' ajoutée à la liste ignore

https://claude.ai/code/session_01HGpdjjeGMs7RdE2JjrtoKC