### PR TITLE
feat: export MusicXML + sauvegarde progression MIDI

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,38 +53,38 @@
 ## v2.0 — Fonctionnalités avancées
 
 - [x] Exercices progressifs : gammes, arpèges, tierces — 6 tonalités, 3 niveaux, aller-retour
-- [ ] Synchronisation MIDI temps réel (WebMIDI API)
-- [ ] Export de partitions simplifiées (MusicXML ou PDF)
-- [ ] Sauvegarde de la progression (localStorage ou backend optionnel)
+- [x] Synchronisation MIDI temps réel (WebMIDI API) — détection + comparaison note active + mode pratique manuel
+- [x] Export de partitions simplifiées (MusicXML)
+- [x] Sauvegarde de la progression (localStorage)
 - [ ] Support multilingue (FR / EN)
 
 ---
 
-## v2.1 — Modèle 3D fidèle 🦊 (en cours)
+## v2.1 — Modèle 3D fidèle 🦊 ✅ (fait)
 
 Refonte visuelle du rendu 3D pour représenter la harpe renard de Marin Lhopiteau
 ([`@october.moth`](https://www.instagram.com/october.moth/), luthier).
 
 ### Forme générale
-- [ ] Colonne (pilier) : profil organique en bois clair, section ovale effilée vers le bas
-- [ ] Table d'harmonie : face triangulaire inclinée, grain bois visible en texture
-- [ ] Console (cou) : courbe prononcée partant de la table, montant vers la tête
+- [x] Colonne (pilier) : profil organique en bois clair, section ovale effilée vers le bas
+- [x] Table d'harmonie : face triangulaire inclinée, grain bois visible en texture
+- [x] Console (cou) : courbe prononcée partant de la table, montant vers la tête
 
 ### Tête sculptée — renard
-- [ ] Tête de renard en bout de console : museau allongé, oreilles pointues, yeux gravés
-- [ ] Pattes avant repliées sous le menton (détail caractéristique du modèle)
-- [ ] Matériau bois chaud (teinte chêne/cerisier clair, `#C68642` environ)
+- [x] Tête de renard en bout de console : museau allongé, oreilles pointues, yeux gravés
+- [x] Pattes avant repliées sous le menton (détail caractéristique du modèle)
+- [x] Matériau bois chaud (teinte chêne/cerisier clair, `#C5893C`)
 
 ### Cordes
-- [ ] 34 cordes (harpe celtique / folk, contre 47 pour la harpe de concert actuelle)
-- [ ] Cordes fines argentées (cylindres à très faible rayon, matériau métallique)
-- [ ] Chevilles apparentes en haut de la console (petites sphères ou cylindres courts)
+- [x] 36 cordes (harpe celtique / folk, contre 47 pour la harpe de concert actuelle)
+- [x] Cordes fines argentées (cylindres à très faible rayon, matériau métallique)
+- [x] Chevilles apparentes en haut de la console (cylindres courts)
 
 ### Technique
-- [ ] Modélisation procédurale Three.js (pas de GLTF externe) ou import d'un `.glb` custom
-- [ ] Matériau `MeshStandardMaterial` avec roughness/metalness pour le bois et le métal
-- [ ] Éclairage chaleureux pour valoriser les teintes bois (warm point light)
-- [ ] Garder l'`OrbitControls` existant pour la rotation libre
+- [x] Modélisation procédurale Three.js (pas de GLTF externe)
+- [x] Matériau `MeshStandardMaterial` avec roughness/metalness pour le bois et le métal
+- [x] Éclairage chaleureux pour valoriser les teintes bois (warm point light `#FFC870`)
+- [x] Garder l'`OrbitControls` existant pour la rotation libre
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,9 @@ import {
   loadHistory,
   recordLoad,
   recordPlay,
+  recordPractice,
 } from './utils/history';
+import { downloadMusicXml } from './utils/musicxmlExport';
 import { useMidi } from './hooks/useMidi';
 import { pitchToMidi } from './utils/midiMapper';
 import ExercisePanel from './components/ExercisePanel';
@@ -49,6 +51,8 @@ function App() {
     null,
   );
   const currentEntryIdRef = useRef<string | null>(null);
+  const practiceCorrectRef = useRef(0);
+  const practiceTotalRef = useRef(0);
 
   // Refs pour éviter les problèmes de closure dans les timers
   const playbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -75,7 +79,18 @@ function App() {
 
   // Réinitialise le curseur de pratique quand une nouvelle partition est chargée
   useEffect(() => {
+    if (currentEntryIdRef.current && practiceTotalRef.current > 0) {
+      setHistory(
+        recordPractice(
+          currentEntryIdRef.current,
+          practiceCorrectRef.current,
+          practiceTotalRef.current,
+        ),
+      );
+    }
     practiceIndexRef.current = 0;
+    practiceCorrectRef.current = 0;
+    practiceTotalRef.current = 0;
     setMidiResult(null);
   }, [notes]);
 
@@ -320,7 +335,9 @@ function App() {
       );
 
       setActiveNoteIndex(idx);
+      practiceTotalRef.current += 1;
       if (midiNote === expected) {
+        practiceCorrectRef.current += 1;
         showMidiResult('correct');
         practiceIndexRef.current = idx + 1;
       } else {
@@ -447,6 +464,17 @@ function App() {
             currentNoteIndex={activeNoteIndex}
             totalNotes={notes.length}
           />
+          {notes.length > 0 && (
+            <button
+              className='btn-export'
+              onClick={() =>
+                downloadMusicXml(notes, divisions, tempo, title || 'partition')
+              }
+              title='Télécharger en MusicXML'
+            >
+              ⬇ Exporter MusicXML
+            </button>
+          )}
           <Canvas camera={{ position: [0, 0, 20], fov: 75 }}>
             <ambientLight intensity={0.5} />
             <directionalLight position={[10, 10, 5]} intensity={1} />

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -13,6 +13,17 @@ const formatDate = (iso: string): string =>
     year: 'numeric',
   });
 
+function bestScore(entry: HistoryEntry): string | null {
+  const sessions = entry.practiceSessions;
+  if (!sessions || sessions.length === 0) return null;
+  const best = Math.max(...sessions.map((s) => s.correct / s.total));
+  return `${Math.round(best * 100)} %`;
+}
+
+function totalPracticeNotes(entry: HistoryEntry): number {
+  return (entry.practiceSessions ?? []).reduce((acc, s) => acc + s.total, 0);
+}
+
 const HistoryPanel: React.FC<HistoryPanelProps> = ({ entries, onClear }) => {
   if (entries.length === 0) {
     return (
@@ -27,16 +38,22 @@ const HistoryPanel: React.FC<HistoryPanelProps> = ({ entries, onClear }) => {
   return (
     <div className='history-panel'>
       <ul className='history-list'>
-        {entries.map((entry) => (
-          <li key={entry.id} className='history-entry'>
-            <span className='history-entry__title'>{entry.title}</span>
-            <span className='history-entry__meta'>
-              {formatDate(entry.loadedAt)}
-              {entry.playCount > 0 &&
-                ` · ${entry.playCount} lecture${entry.playCount > 1 ? 's' : ''}`}
-            </span>
-          </li>
-        ))}
+        {entries.map((entry) => {
+          const score = bestScore(entry);
+          const practiced = totalPracticeNotes(entry);
+          return (
+            <li key={entry.id} className='history-entry'>
+              <span className='history-entry__title'>{entry.title}</span>
+              <span className='history-entry__meta'>
+                {formatDate(entry.loadedAt)}
+                {entry.playCount > 0 &&
+                  ` · ${entry.playCount} lecture${entry.playCount > 1 ? 's' : ''}`}
+                {practiced > 0 && ` · ${practiced} notes pratiquées`}
+                {score && ` · meilleur score : ${score}`}
+              </span>
+            </li>
+          );
+        })}
       </ul>
       <button className='btn-clear-history' onClick={onClear}>
         Tout effacer

--- a/src/styles.css
+++ b/src/styles.css
@@ -514,3 +514,20 @@ input:focus, textarea:focus {
     opacity: 1;
   }
 }
+
+.btn-export {
+  display: block;
+  margin: 8px auto 0;
+  padding: 6px 16px;
+  background: #ecf0f1;
+  border: 1px solid #bdc3c7;
+  border-radius: 6px;
+  color: #2c3e50;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-export:hover {
+  background: #d5dbdb;
+}

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,3 +1,9 @@
+export interface PracticeSession {
+  date: string;
+  correct: number;
+  total: number;
+}
+
 export interface HistoryEntry {
   id: string;
   title: string;
@@ -5,6 +11,7 @@ export interface HistoryEntry {
   loadedAt: string;
   playCount: number;
   lastPlayedAt?: string;
+  practiceSessions?: PracticeSession[];
 }
 
 const STORAGE_KEY = 'sonare-history';
@@ -49,6 +56,30 @@ export const recordPlay = (id: string): HistoryEntry[] => {
   if (entry) {
     entry.playCount += 1;
     entry.lastPlayedAt = new Date().toISOString();
+    saveHistory(entries);
+  }
+  return entries;
+};
+
+export const recordPractice = (
+  id: string,
+  correct: number,
+  total: number,
+): HistoryEntry[] => {
+  if (total === 0) return loadHistory();
+  const entries = loadHistory();
+  const entry = entries.find((e) => e.id === id);
+  if (entry) {
+    if (!entry.practiceSessions) entry.practiceSessions = [];
+    entry.practiceSessions.push({
+      date: new Date().toISOString(),
+      correct,
+      total,
+    });
+    // Garder au maximum 50 sessions par entrée
+    if (entry.practiceSessions.length > 50) {
+      entry.practiceSessions = entry.practiceSessions.slice(-50);
+    }
     saveHistory(entries);
   }
   return entries;

--- a/src/utils/musicxmlExport.test.ts
+++ b/src/utils/musicxmlExport.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { exportMusicXml } from './musicxmlExport';
+import { Note } from 'musicxml-interfaces';
+
+type Step = 'C' | 'D' | 'E' | 'F' | 'G' | 'A' | 'B';
+
+function makeNote(step: string, octave: number, duration = 4, alter = 0): Note {
+  return {
+    pitch: { step: step as Step, octave, alter },
+    duration,
+  } as Note;
+}
+
+function makeRest(duration = 4): Note {
+  return { rest: {}, duration } as Note;
+}
+
+describe('exportMusicXml', () => {
+  it('produit un document XML valide avec la déclaration et le DOCTYPE', () => {
+    const xml = exportMusicXml([makeNote('C', 4)], 4, 120, 'Test');
+    expect(xml).toContain('<?xml version="1.0"');
+    expect(xml).toContain('score-partwise');
+  });
+
+  it('inclut le titre dans work-title', () => {
+    const xml = exportMusicXml([makeNote('C', 4)], 4, 120, 'Ma gamme');
+    expect(xml).toContain('<work-title>Ma gamme</work-title>');
+  });
+
+  it('inclut le tempo dans sound', () => {
+    const xml = exportMusicXml([makeNote('C', 4)], 4, 80, 'Test');
+    expect(xml).toContain('tempo="80"');
+  });
+
+  it('encode correctement une note C4', () => {
+    const xml = exportMusicXml([makeNote('C', 4)], 4, 120, 'T');
+    expect(xml).toContain('<step>C</step>');
+    expect(xml).toContain('<octave>4</octave>');
+    expect(xml).toContain('<duration>4</duration>');
+  });
+
+  it('encode un dièse (alter=1)', () => {
+    const xml = exportMusicXml([makeNote('F', 5, 4, 1)], 4, 120, 'T');
+    expect(xml).toContain('<alter>1</alter>');
+  });
+
+  it('encode un bémol (alter=-1)', () => {
+    const xml = exportMusicXml([makeNote('B', 4, 4, -1)], 4, 120, 'T');
+    expect(xml).toContain('<alter>-1</alter>');
+  });
+
+  it('encode un silence avec <rest/>', () => {
+    const xml = exportMusicXml([makeRest()], 4, 120, 'T');
+    expect(xml).toContain('<rest/>');
+  });
+
+  it('produit plusieurs mesures pour une longue partition', () => {
+    // 4 noires par mesure (divisions=4), 8 noires = 2 mesures
+    const notes = Array.from({ length: 8 }, () => makeNote('C', 4, 4));
+    const xml = exportMusicXml(notes, 4, 120, 'T');
+    expect(xml).toContain('measure number="1"');
+    expect(xml).toContain('measure number="2"');
+  });
+
+  it('inclut les divisions dans la première mesure seulement', () => {
+    const notes = Array.from({ length: 8 }, () => makeNote('C', 4, 4));
+    const xml = exportMusicXml(notes, 4, 120, 'T');
+    const count = (xml.match(/<divisions>/g) ?? []).length;
+    expect(count).toBe(1);
+  });
+
+  it('type "whole" pour une ronde (duration = 4 × divisions)', () => {
+    const xml = exportMusicXml([makeNote('C', 4, 16)], 4, 120, 'T');
+    expect(xml).toContain('<type>whole</type>');
+  });
+
+  it('type "eighth" pour une croche (duration = divisions / 2)', () => {
+    const xml = exportMusicXml([makeNote('C', 4, 2)], 4, 120, 'T');
+    expect(xml).toContain('<type>eighth</type>');
+  });
+});

--- a/src/utils/musicxmlExport.ts
+++ b/src/utils/musicxmlExport.ts
@@ -1,0 +1,116 @@
+import { Note } from 'musicxml-interfaces';
+
+function alterToAccidental(alter: number): string {
+  if (alter === 1) return '<alter>1</alter>';
+  if (alter === -1) return '<alter>-1</alter>';
+  return '';
+}
+
+function durationToType(duration: number, divisions: number): string {
+  const ratio = duration / divisions;
+  if (ratio >= 4) return 'whole';
+  if (ratio >= 2) return 'half';
+  if (ratio >= 1) return 'quarter';
+  if (ratio >= 0.5) return 'eighth';
+  return '16th';
+}
+
+function noteToXml(note: Note, divisions: number): string {
+  const dur = note.duration ?? divisions;
+  const type = durationToType(dur, divisions);
+
+  if (note.rest !== undefined) {
+    return `      <note><rest/><duration>${dur}</duration><type>${type}</type></note>`;
+  }
+
+  const p = note.pitch!;
+  const alter = p.alter ?? 0;
+  const chord = note.chord !== undefined ? '      <chord/>\n' : '';
+
+  return (
+    `${chord}      <note>\n` +
+    `        <pitch><step>${p.step}</step>${alterToAccidental(alter)}<octave>${p.octave}</octave></pitch>\n` +
+    `        <duration>${dur}</duration>\n` +
+    `        <type>${type}</type>\n` +
+    `      </note>`
+  );
+}
+
+export function exportMusicXml(
+  notes: Note[],
+  divisions: number,
+  tempo: number,
+  title: string,
+): string {
+  const beatsPerMeasure = 4;
+  const measureDuration = beatsPerMeasure * divisions;
+
+  // Regroupe les notes en mesures
+  const measures: Note[][] = [];
+  let current: Note[] = [];
+  let fill = 0;
+
+  for (const note of notes) {
+    const dur = note.duration ?? divisions;
+    if (note.chord === undefined) {
+      if (fill + dur > measureDuration && current.length > 0) {
+        measures.push(current);
+        current = [];
+        fill = 0;
+      }
+      fill += dur;
+    }
+    current.push(note);
+  }
+  if (current.length > 0) measures.push(current);
+
+  const measuresXml = measures
+    .map((m, i) => {
+      const attrs =
+        i === 0
+          ? `\n      <attributes>` +
+            `\n        <divisions>${divisions}</divisions>` +
+            `\n        <key><fifths>0</fifths></key>` +
+            `\n        <time><beats>4</beats><beat-type>4</beat-type></time>` +
+            `\n        <clef><sign>G</sign><line>2</line></clef>` +
+            `\n      </attributes>` +
+            `\n      <direction placement="above">` +
+            `\n        <direction-type><words>${title}</words></direction-type>` +
+            `\n        <sound tempo="${tempo}"/>` +
+            `\n      </direction>`
+          : '';
+      const notesXml = m.map((n) => noteToXml(n, divisions)).join('\n');
+      return `    <measure number="${i + 1}">${attrs}\n${notesXml}\n    </measure>`;
+    })
+    .join('\n');
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">\n` +
+    `<score-partwise version="3.1">\n` +
+    `  <work><work-title>${title}</work-title></work>\n` +
+    `  <part-list><score-part id="P1"><part-name>Harpe</part-name></score-part></part-list>\n` +
+    `  <part id="P1">\n` +
+    measuresXml +
+    `\n  </part>\n` +
+    `</score-partwise>\n`
+  );
+}
+
+export function downloadMusicXml(
+  notes: Note[],
+  divisions: number,
+  tempo: number,
+  title: string,
+): void {
+  const xml = exportMusicXml(notes, divisions, tempo, title);
+  const blob = new Blob([xml], {
+    type: 'application/vnd.recordare.musicxml+xml',
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${title.replace(/[^a-zA-Z0-9_-]/g, '_') || 'partition'}.musicxml`;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
- musicxmlExport.ts : génère un fichier .musicxml téléchargeable depuis
  n'importe quelle partition chargée ou exercice généré (11 tests)
- history.ts : nouveau type PracticeSession + recordPractice() pour
  persister les scores MIDI (correct/total) par entrée d'historique
- HistoryPanel : affiche les notes pratiquées et le meilleur score %
- App.tsx : bouton "Exporter MusicXML", compteurs correct/total réinitialisés
  et sauvegardés à chaque changement de partition
- ROADMAP : v2.0 export + progression marqués ✓, v2.1 complété

https://claude.ai/code/session_01HGpdjjeGMs7RdE2JjrtoKC