### PR TITLE
feat: allumage simultané des cordes + refactor collectChordGroup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { Note } from 'musicxml-interfaces';
 import HarpModel from './components/HarpModel';
 import ScoreLoader from './components/ScoreLoader';
 import UIControls from './components/UIControls';
-import { getRecommendedFinger } from './utils/noteMapper';
+import { collectChordGroup, getRecommendedFinger } from './utils/noteMapper';
 import { DEFAULT_VOLUME } from './utils/xmlParser';
 import HistoryPanel from './components/HistoryPanel';
 import {
@@ -219,19 +219,7 @@ function App() {
         return;
       }
 
-      // Collecte la note de base + toutes les notes d'accord qui suivent
-      const chordEnd = (() => {
-        let i = index + 1;
-        while (
-          i < partitionCourante.length &&
-          partitionCourante[i].chord !== undefined
-        )
-          i++;
-        return i;
-      })();
-      setActiveNoteIndices(
-        Array.from({ length: chordEnd - index }, (_, k) => index + k),
-      );
+      setActiveNoteIndices(collectChordGroup(partitionCourante, index));
 
       const isTiedStop = note.ties?.some((t) => (t.type as number) === 1);
       if (note.rest === undefined && !isTiedStop) {

--- a/src/utils/noteMapper.test.ts
+++ b/src/utils/noteMapper.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  collectChordGroup,
   getRecommendedFinger,
   mapPitchToString,
   STRING_COUNT,
@@ -107,5 +108,32 @@ describe('getRecommendedFinger', () => {
   it('retourne null pour un step inconnu', () => {
     expect(getRecommendedFinger('X')).toBeNull();
     expect(getRecommendedFinger('')).toBeNull();
+  });
+});
+
+describe('collectChordGroup', () => {
+  const n = (chord?: true) => ({ chord: chord ? {} : undefined });
+
+  it('note isolée → [0]', () => {
+    expect(collectChordGroup([n(), n(), n()], 0)).toEqual([0]);
+  });
+
+  it('accord de 3 notes → [1, 2, 3]', () => {
+    const notes = [n(), n(), n(true), n(true), n()];
+    expect(collectChordGroup(notes, 1)).toEqual([1, 2, 3]);
+  });
+
+  it("accord en fin de tableau → collecte jusqu'au bout", () => {
+    const notes = [n(), n(true), n(true)];
+    expect(collectChordGroup(notes, 0)).toEqual([0, 1, 2]);
+  });
+
+  it('note seule en fin de tableau → [dernierIndex]', () => {
+    const notes = [n(), n(), n()];
+    expect(collectChordGroup(notes, 2)).toEqual([2]);
+  });
+
+  it('tableau vide → [0] (baseIdx hors limite, pas de boucle)', () => {
+    expect(collectChordGroup([], 0)).toEqual([0]);
   });
 });

--- a/src/utils/noteMapper.ts
+++ b/src/utils/noteMapper.ts
@@ -37,6 +37,24 @@ export const mapPitchToString = (pitch: Pitch): number => {
 };
 
 /**
+ * Retourne les indices (dans le tableau notes[]) de toutes les notes formant
+ * l'accord à partir de baseIdx : la note de base + toutes les notes suivantes
+ * marquées chord !== undefined.
+ */
+export const collectChordGroup = <T extends { chord?: unknown }>(
+  notes: T[],
+  baseIdx: number,
+): number[] => {
+  const result = [baseIdx];
+  let i = baseIdx + 1;
+  while (i < notes.length && notes[i].chord !== undefined) {
+    result.push(i);
+    i++;
+  }
+  return result;
+};
+
+/**
  * Retourne le doigt recommandé pour une note (1 = pouce … 4 = annulaire).
  * Utilisé pour l'affichage pédagogique du doigté.
  */


### PR DESCRIPTION
## Résumé

- **Vérification** : tous les Do-Ré-Mi-Fa-Sol-La-Si s'allument bien en jaune (#FFE45A) quand ils sont joués — `stringColor` retourne `STRING_ACTIVE` en priorité, avant le test rouge (Do) / noir (Fa).
- **Accords simultanés** : `activeNoteIndices: number[]` + `activeVisualSet: Set<number>` dans HarpModel permettent d'allumer autant de cordes que nécessaire en même temps.
- **Refactor** : extraction de `collectChordGroup` (noteMapper.ts) à la place d'un IIFE anonyme dans `jouerDepuis`. Fonction générique, testable indépendamment.

## Tests ajoutés

5 cas dans `noteMapper.test.ts` :
- [ ] Note isolée → `[baseIdx]`
- [ ] Accord de 3 notes → indices contigus
- [ ] Accord en fin de tableau → collecte jusqu'au bout
- [ ] Note finale seule
- [ ] Tableau vide (baseIdx hors limite)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGpdjjeGMs7RdE2JjrtoKC)_